### PR TITLE
chore: standardize automation workflows + dependabot config

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   dependabot:
     if: ${{ github.actor == 'dependabot[bot]' && github.event.pull_request.draft == false }}
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Fetch Dependabot metadata
         id: meta

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -44,7 +44,7 @@ jobs:
   scan:
     # Gitleaks does not need self-hosted resources; ubuntu-latest avoids
     # gitleaks-action@v2 install failures on self-hosted runners.
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -59,8 +59,10 @@ jobs:
       - name: Install gitleaks
         run: |
           wget -qO /tmp/gitleaks.tar.gz "https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz"
-          sudo tar -xzf /tmp/gitleaks.tar.gz -C /usr/local/bin gitleaks
-          sudo chmod +x /usr/local/bin/gitleaks
+          mkdir -p "$HOME/.local/bin"
+          tar -xzf /tmp/gitleaks.tar.gz -C "$HOME/.local/bin" gitleaks
+          chmod +x "$HOME/.local/bin/gitleaks"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Run gitleaks detect
         run: |

--- a/.github/workflows/pr-auto-merge.yml
+++ b/.github/workflows/pr-auto-merge.yml
@@ -35,7 +35,7 @@ concurrency:
 
 jobs:
   enable-auto-merge:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 5
     # Trigger on either:
     #   1. an APPROVED review on a non-draft, non-bot PR

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -10,6 +10,11 @@ permissions:
 
 jobs:
   pr-checks:
+    # Run for every PR including dependabot[bot]. The required status
+    # contexts on branch protection (Check PR Title, Check Branch Name)
+    # apply to dependabot too; Dependabot satisfies them automatically
+    # because conventional commit titles and feat/fix/chore branch names
+    # are its default behavior.
     if: github.event_name == 'pull_request'
-    uses: ./.github/workflows/reusable-pr-checks.yml
+    uses: jclee941/.github/.github/workflows/reusable-pr-checks.yml@master
     secrets: inherit

--- a/.github/workflows/reusable-pr-checks.yml
+++ b/.github/workflows/reusable-pr-checks.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   check-size:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     name: Check PR Size
     steps:
@@ -49,7 +49,7 @@ jobs:
 
   check-title:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     name: Check PR Title
     steps:
@@ -75,7 +75,7 @@ jobs:
 
   check-branch:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     name: Check Branch Name
     steps:
@@ -101,7 +101,7 @@ jobs:
 
   check-description:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     name: Check PR Description
     steps:
@@ -144,7 +144,7 @@ jobs:
 
   check-large-files:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     name: Check Large Files
     steps:
@@ -181,7 +181,7 @@ jobs:
 
   check-sensitive-files:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     name: Check Sensitive Files
     steps:


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **Issue management + docs sync** workflows.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`gitleaks.yml`, `codeql.yml`, `actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Enhancement, Other


___

### **Description**
- 프라이빗 저장소 조건부 self-hosted 러너 적용

- gitleaks 사용자 로컬 bin 설치 경로 변경

- 재사용 PR 체크 중앙 저장소 참조 변경

- Dependabot 및 PR 자동머지 self-hosted 전환


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dependabot-auto-merge.yml</strong><dd><code>Dependabot 자동머지 self-hosted 전환</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/dependabot-auto-merge.yml

<ul><li><code>runs-on</code>를 <code>ubuntu-latest</code>에서 <code>self-hosted</code>로 변경<br> <li> Dependabot PR 자동머지 작업의 실행 환경을 조직 self-hosted 러너로 전환</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/bug/pull/52/files#diff-2fe48d1021006468ac63263583b5db615dd5e63a39ebff862cc4e2f06b59caa1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gitleaks.yml</strong><dd><code>gitleaks 워크플로우 self-hosted 및 설치 개선</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/gitleaks.yml

<ul><li><code>runs-on</code>를 private 저장소 조건부 <code>self-hosted</code>로 변경<br> <li> gitleaks 바이너리 설치 경로를 <code>/usr/local/bin</code>에서 <code>$HOME/.local/bin</code>으로 변경<br> <li> <code>$GITHUB_PATH</code>에 사용자 로컬 bin 디렉터리를 추가하여 PATH 등록</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/bug/pull/52/files#diff-2aa7a05eafb406b4c582ed3bd35f2ef3a6fadeaad31372f62a79bd7610e1e453">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pr-auto-merge.yml</strong><dd><code>PR 자동머지 self-hosted 전환</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-auto-merge.yml

<ul><li><code>runs-on</code>를 <code>ubuntu-latest</code>에서 <code>self-hosted</code>로 변경<br> <li> PR 자동머지 활성화 작업의 실행 환경을 self-hosted 러너로 전환</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/bug/pull/52/files#diff-61c0d56ab06ca0109392dffccd6cf28b542b40fe66cdc5db85f8b6da53e9395d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pr-checks.yml</strong><dd><code>PR 체크 워크플로우 중앙 저장소 참조 변경</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-checks.yml

<ul><li>재사용 워크플로우 참조를 <code>./.github/workflows/reusable-pr-checks.yml</code>에서 <br><code>jclee941/.github/.github/workflows/reusable-pr-checks.yml@master</code>로 변경<br> <li> Dependabot PR에도 PR 체크가 실행됨을 설명하는 주석 추가</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/bug/pull/52/files#diff-1da7a27709d11ac16eef3de8e46ed10672b7b1d63a790ffbcbd23a94b19efdcb">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>reusable-pr-checks.yml</strong><dd><code>재사용 PR 체크 작업 self-hosted 조건부 적용</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/reusable-pr-checks.yml

<ul><li><code>check-size</code>, <code>check-title</code>, <code>check-branch</code>, <code>check-description</code>, <br><code>check-large-files</code>, <code>check-sensitive-files</code> 작업의 <code>runs-on</code>을 private 저장소 조건부 <br><code>self-hosted</code>로 일괄 변경<br> <li> 공개 저장소는 기존 <code>ubuntu-latest</code> 유지</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/bug/pull/52/files#diff-c847d70b033c8a55778bee6b336f27519c76efbe8d9f7b8c67108ef006d42ee7">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

