### PR TITLE
chore: standardize automation workflows + dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,27 @@ updates:
           - "minor"
           - "patch"
 
+  # JavaScript/TypeScript dependencies (package.json + package-lock.json)
+  # Dependabot skips repos without these manifest files, so this is safe
+  # for all downstream repos.
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "javascript"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      npm-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+
   # Go scripts (go.mod) - none yet, but ready when scripts/ gets a go.mod
   # - package-ecosystem: "gomod"
   #   directory: "/scripts"


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **Issue management + docs sync** workflows.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`gitleaks.yml`, `codeql.yml`, `actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Enhancement


___

### **Description**
- `.github/dependabot.yml`에 `npm` 패키지 생태계 설정 추가

- JavaScript/TypeScript 의존성에 대한 주간 Dependabot 업데이트 활성화

- `minor` 및 `patch` 업데이트를 `npm-minor-patch` 그룹으로 자동 묶음


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[".github/dependabot.yml"] -- "npm 생태계 추가" --> B["package.json / package-lock.json 주간 스캔"]
  B -- "그룹핑" --> C["npm-minor-patch 그룹"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dependabot.yml</strong><dd><code>Dependabot 설정에 npm 패키지 생태계 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/dependabot.yml

<ul><li><code>npm</code> 패키지 생태계 설정 블록을 신규 추가함<br> <li> 루트 디렉터리(<code>directory: "/"</code>)의 <code>package.json</code> 및 <code>package-lock.json</code>을 대상으로 설정<br> <li> 주간 스케줄, <code>dependencies</code> 및 <code>javascript</code> 라벨, <code>chore</code> 커밋 프리픽스를 구성<br> <li> <code>npm-minor-patch</code> 그룹으로 <code>minor</code>와 <code>patch</code> 업데이트를 자동 묶도록 설정</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/bug/pull/53/files#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28">+21/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

