### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -26,5 +26,3 @@ jobs:
     timeout-minutes: 15
     uses: jclee941/.github/.github/workflows/reusable-docs-sync.yml@master
     secrets: inherit
-    uses: jclee941/.github/.github/workflows/reusable-docs-sync.yml@master
-    secrets: inherit

--- a/.github/workflows/readme-gen.yml
+++ b/.github/workflows/readme-gen.yml
@@ -1,0 +1,109 @@
+name: README Generator
+
+on:
+  # Manual trigger
+  workflow_dispatch:
+  # Weekly auto-generation (Sundays 00:00 UTC)
+  schedule:
+    - cron: '0 0 * * 0'
+  # Trigger when source/config files change on master
+  push:
+    branches: [master, main]
+    paths-ignore:
+      - 'README.md'
+      - '.github/workflows/readme-gen.yml'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: readme-gen-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  generate_readme:
+    if: github.repository != 'jclee941/.github'  # skip source repo
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
+    name: Generate README.md via CLIProxyAPI
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Check out readme generator script
+        uses: actions/checkout@v6
+        with:
+          repository: jclee941/.github
+          ref: master
+          path: _bot-scripts
+          sparse-checkout: |
+            scripts/generate_readme.py
+          fetch-depth: 1
+
+      - name: Generate README.md
+        env:
+          CLIPROXY_API_KEY: ${{ secrets.CLIPROXY_API_KEY }}
+          OPENAI_BASE_URL: https://cliproxy.jclee.me/v1
+        run: |
+          set -e
+          python3 _bot-scripts/scripts/generate_readme.py --repo .
+
+      - name: Check for changes
+        id: diff
+        run: |
+          if git diff --quiet README.md; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No changes to README.md"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "README.md changed"
+          fi
+
+      - name: Commit and push to branch
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          set -e
+          git config user.email "bot@jclee.me"
+          git config user.name "github-bot"
+          git checkout -b bot/auto-readme-update
+          git add README.md
+          git commit -m "docs: auto-update README.md [skip ci]"
+          gh auth setup-git
+          git push -u origin bot/auto-readme-update --force-with-lease
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create or update PR
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          set -e
+          existing=$(gh pr list --head bot/auto-readme-update --json number --jq '.[0].number')
+          if [ -n "$existing" ]; then
+            gh pr edit "$existing" --title "docs: auto-update README.md" --body "Automated README.md update by jclee-bot."
+          else
+            gh pr create \
+              --title "docs: auto-update README.md" \
+              --body "Automated README.md update by jclee-bot." \
+              --base "${GITHUB_REF_NAME}" \
+              --head bot/auto-readme-update
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          set -e
+          pr_number=$(gh pr list --head bot/auto-readme-update --json number --jq '.[0].number')
+          gh pr merge "$pr_number" --auto --squash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (kimi-k2.6 → minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`gitleaks.yml`, `codeql.yml`, `actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- README 자동 생성 워크플로우 추가

- docs-sync 워크플로우 중복 항목 제거

- README 업데이트 PR 자동 머지 설정


___

### Diagram Walkthrough


```mermaid
flowchart LR
  trigger["트리거 이벤트"] --> checkout["저장소 체크아웃"]
  checkout --> generate["CLIProxyAPI로 README 생성"]
  generate --> diff{"변경 감지?"}
  diff -- "예" --> pr["PR 생성/갱신"]
  pr --> merge["자동 머지 활성화"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>readme-gen.yml</strong><dd><code>README 자동 생성 워크플로우 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/readme-gen.yml

<ul><li><code>README.md</code> 자동 생성 워크플로우 신규 작성<br> <li> <code>CLIPROXY_API_KEY</code>를 활용한 <code>generate_readme.py</code> 실행<br> <li> 변경 사항 자동 커밋 및 PR 생성/갱신<br> <li> 스쿼시 자동 머지 활성화</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/bug/pull/67/files#diff-f9347e8d7f39ffd679c6b9e3031a4e05bf239457bb5c4d31dc89130ad26cd462">+109/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docs-sync.yml</strong><dd><code>docs-sync 워크플로우 중복 제거</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/docs-sync.yml

- 중복된 `uses` 호출 문 제거
- 중복된 `secrets: inherit` 선언 제거


</details>


  </td>
  <td><a href="https://github.com/jclee941/bug/pull/67/files#diff-f4bfcbba69692fc3c503c6de06be0057b3d1cd35571b3d0e7f14ad12737f217d">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

