### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/workflows/29_downstream-health-check.yml
+++ b/.github/workflows/29_downstream-health-check.yml
@@ -29,18 +29,20 @@ jobs:
         uses: step-security/harden-runner@v2
         with:
           egress-policy: audit
-      - name: Checkout repository inventory
-        uses: actions/checkout@v6
-        with:
-          repository: jclee941/.github
-          path: .github-inventory
-
+      # Default-path checkout MUST come first: actions/checkout cleans the
+      # workspace root, which would wipe a previously-checked-out subdir.
       - name: Checkout local actions
         uses: actions/checkout@v6
         with:
           repository: jclee941/.github
           ref: master
           fetch-depth: 1
+
+      - name: Checkout repository inventory
+        uses: actions/checkout@v6
+        with:
+          repository: jclee941/.github
+          path: .github-inventory
 
       - name: Check latest workflow runs across all repos
         id: health


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `12_dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`20_readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`05_gitleaks.yml`, `06_codeql.yml`, `04_actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Bug fix


___

### **Description**
- 체크아웃 순서 변경으로 작업 공간 삭제 방지

- 루트 체크아웃 선행 필요성에 대한 주석 추가

- 저장소 인벤토리 하위 디렉터리가 유지되도록 수정


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A["Checkout local actions<br/>(root workspace)"] -- "prevents wipe" --> B["Checkout repository inventory<br/>(.github-inventory path)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>29_downstream-health-check.yml</strong><dd><code>체크아웃 순서 변경으로 인벤토리 디렉터리 보존</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/29_downstream-health-check.yml

<ul><li><code>actions/checkout</code> 단계 순서를 변경하여 기본 경로(루트) 체크아웃이 하위 디렉터리 체크아웃보다 먼저 실행되도록 <br>수정<br> <li> 루트 체크아웃 시 작업 공간이 정리되어 이전에 체크아웃한 하위 디렉터리가 삭제될 수 있다는 설명 주석 추가<br> <li> <code>.github-inventory</code> 경로의 저장소 인벤토리가 이후 단계에서 정상적으로 사용되도록 보장</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/bug/pull/142/files#diff-0a2d1fa5e4f41ad7db3bbc643780738a3f440dc3f1b0731eb925db7fd7369f9b">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

