### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/workflows/29_downstream-health-check.yml
+++ b/.github/workflows/29_downstream-health-check.yml
@@ -58,7 +58,10 @@ jobs:
           for REPO in $REPOS; do
             FULL="jclee941/$REPO"
             for WF in "${WORKFLOWS[@]}"; do
-              LATEST=$(gh run list -R "$FULL" --workflow "$WF" --limit 1 --json conclusion,status,createdAt --jq '.[0]')
+              # Tolerate repos/workflows that don't exist: gh exits non-zero
+              # ("could not find any workflows named ...") which would abort the
+              # step under bash -e. Fall back to empty and skip via the check below.
+              LATEST=$(gh run list -R "$FULL" --workflow "$WF" --limit 1 --json conclusion,status,createdAt --jq '.[0]' 2>/dev/null || true)
               if [ -z "$LATEST" ] || [ "$LATEST" = "[]" ]; then
                 continue
               fi


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `12_dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`20_readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`05_gitleaks.yml`, `06_codeql.yml`, `04_actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix error handling for `gh run list` command in downstream health check workflow

- Add `2>/dev/null || true` to suppress non-zero exit when repo/workflow doesn't exist

- Prevents step failure under `bash -e` for repos without configured workflows (actionlint, pr-checks, gitleaks)

- Existing empty check handles fallback gracefully


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["gh run list"] --> B{"Exit code"}
  B -->|0| C["Process result"]
  B -->|non-zero| D["Suppress error<br/>2>/dev/null || true"]
  D --> E["Fall back to empty"]
  E --> F["Skip via existing<br/>empty check"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>29_downstream-health-check.yml</strong><dd><code>Fix gh run list error handling for missing workflows</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/29_downstream-health-check.yml

<ul><li>Add error suppression for <code>gh run list</code> command with <code>2>/dev/null || true</code><br> <li> Tolerate repos/workflows that don't exist without failing the step<br> <li> Maintain existing empty/null check logic for skipping missing <br>workflows<br> <li> Comment explains the <code>bash -e</code> behavior this fixes</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/bug/pull/147/files#diff-0a2d1fa5e4f41ad7db3bbc643780738a3f440dc3f1b0731eb925db7fd7369f9b">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

