### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/workflows/20_readme-gen.yml
+++ b/.github/workflows/20_readme-gen.yml
@@ -78,13 +78,23 @@ jobs:
           set -eu
           git config user.email "bot@jclee.me"
           git config user.name "github-bot"
-          git checkout -b bot/auto-readme-update
+          # Re-create the bot branch from the freshly generated state.
+          # checkout -B is idempotent across repeated runs (fixed branch name),
+          # and --force below handles both the first run (no remote branch yet)
+          # and re-runs (existing remote branch) without a 'stale info' lease
+          # error. This is a bot-owned branch with the bot as sole writer, and
+          # the workflow concurrency group serialises runs, so --force is safe.
+          git checkout -B bot/auto-readme-update
           git add README.md
-          git commit -m "docs: auto-update README.md [skip ci]"
+          # No [skip ci]: the PR needs its required checks to run so auto-merge
+          # can be satisfied.
+          git commit -m "docs: auto-update README.md"
           gh auth setup-git
-          git push -u origin bot/auto-readme-update --force-with-lease
+          git push -u origin bot/auto-readme-update --force
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GH_PAT (not GITHUB_TOKEN) so the pushed branch triggers PR checks and
+          # auto-merge can fire.
+          GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Create or update PR
         if: steps.diff.outputs.changed == 'true'
@@ -101,7 +111,7 @@ jobs:
               --head bot/auto-readme-update
           fi
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Enable auto-merge
         if: steps.diff.outputs.changed == 'true'
@@ -110,7 +120,7 @@ jobs:
           pr_number=$(gh pr list --head bot/auto-readme-update --json number --jq '.[0].number')
           gh pr merge "$pr_number" --auto --squash
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
       - name: Notify on failure
         if: failure()
         uses: ./.github/actions/notify-on-failure


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `12_dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`20_readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`05_gitleaks.yml`, `06_codeql.yml`, `04_actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- `[skip ci]` 제거하여 PR 필수 체크 정상 실행

- 봇 브랜치 반복 실행 시 `--force` 안정화 적용

- `GH_PAT` 도입으로 PR 체크 트리거 및 자동 병합 가능

- `checkout -B`로 봇 브랜치 재생성 idempotency 확보


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["README 변경 감지"] --> B["bot/auto-readme-update<br/>브랜치 체크아웃 -B"]
  B --> C["커밋<br/>([skip ci] 제거)"]
  C --> D["force push<br/>(GH_PAT 사용)"]
  D --> E["PR 체크 실행"]
  E --> F["자동 병합"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>20_readme-gen.yml</strong><dd><code>봇 브랜치 처리 안정화 및 PAT 기반 PR 체크/자동 병합 개선</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/20_readme-gen.yml

<ul><li><code>git checkout -B</code> 및 <code>git push --force</code> 적용으로 봇 전용 브랜치의 반복 생성/갱신 시 발생하던 <br><code>stale info</code> 오류와 충돌을 제거<br> <li> 커밋 메시지에서 <code>[skip ci]</code>를 제거하여 생성된 PR이 저장소의 필수 상태 체크를 정상적으로 통과하고 자동 병합 조건을 <br>만족하도록 수정<br> <li> 워크플로우 내 <code>secrets.GITHUB_TOKEN</code>을 <code>secrets.GH_PAT || secrets.GITHUB_TOKEN</code>로 <br>변경하여, 봇이 푸시한 브랜치에서 PR 체크 워크플로우가 트리거되고 <code>auto-merge</code>가 동작하도록 개선<br> <li> 동일한 토큰 변경을 커밋·푸시, PR 생성/업데이트, 자동 병합 단계에 일관되게 적용</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/bug/pull/151/files#diff-3151312623e64c1035ee16621695ce8cf19800d6f70cb01f238c4d309d518c5a">+16/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

