### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/workflows/21_docs-sync.yml
+++ b/.github/workflows/21_docs-sync.yml
@@ -24,4 +24,6 @@ jobs:
   docs-sync:
     if: github.event_name == 'push' || github.event_name == 'pull_request'
     uses: jclee941/.github/.github/workflows/42_reusable-docs-sync.yml@master
+    with:
+      is_pull_request: ${{ github.event_name == 'pull_request' }}
     secrets: inherit

--- a/.github/workflows/42_reusable-docs-sync.yml
+++ b/.github/workflows/42_reusable-docs-sync.yml
@@ -1,6 +1,16 @@
 name: Reusable Documentation Sync
 on:
   workflow_call:
+    inputs:
+      is_pull_request:
+        description: >-
+          Whether the calling workflow was triggered by a pull_request event.
+          Reusable workflows run with github.event_name == 'workflow_call',
+          so the caller must forward its own event via this input; otherwise
+          PR-only jobs would silently skip in downstream repos.
+        required: false
+        default: false
+        type: boolean
   workflow_dispatch:
 
 permissions:
@@ -14,7 +24,7 @@ concurrency:
 
 jobs:
   link-check:
-    if: github.event_name == 'pull_request'
+    if: ${{ inputs.is_pull_request }}
     runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:
@@ -61,8 +71,55 @@ jobs:
               labels: ['documentation', 'bot', 'broken-links']
             });
 
+  private-ip-check:
+    # Detect hardcoded RFC 1918 private IPs in Markdown docs. Runs against
+    # downstream repos too: they call this reusable workflow via the central
+    # `@master` reference, so edits here propagate without re-deploy. The
+    # detector script is pulled from jclee941/.github so downstream repos need
+    # not vendor it.
+    if: ${{ inputs.is_pull_request }}
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
+    timeout-minutes: 10
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
+      - name: Checkout PR
+        uses: actions/checkout@v6
+        with:
+          path: pr
+
+      - name: Checkout detector script (from jclee941/.github)
+        uses: actions/checkout@v6
+        with:
+          repository: jclee941/.github
+          ref: master
+          path: tooling
+          sparse-checkout: |
+            scripts/check_private_ips.py
+          sparse-checkout-cone-mode: false
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Scan Markdown for hardcoded private IPs
+        run: |
+          set -eu
+          python tooling/scripts/check_private_ips.py pr \
+            2> ip-report.txt || EXIT=$?
+          cat ip-report.txt || true
+          if [ "${EXIT:-0}" -ne 0 ]; then
+            echo "::error::Hardcoded private IP(s) found in Markdown docs. See log above."
+            exit 1
+          fi
+
+
   markdown-lint:
-    if: github.event_name == 'pull_request'
+    if: ${{ inputs.is_pull_request }}
     runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:
@@ -97,7 +154,7 @@ jobs:
   readme-sync-check:
     runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
-    if: github.event_name == 'pull_request'
+    if: ${{ inputs.is_pull_request }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@v2
@@ -158,7 +215,7 @@ jobs:
   api-docs-check:
     runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
-    if: github.event_name == 'pull_request'
+    if: ${{ inputs.is_pull_request }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@v2


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `12_dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`20_readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`05_gitleaks.yml`, `06_codeql.yml`, `04_actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- 호출자에서 재사용 워크플로우로 PR 여부 전달

- PR 전용 문서 작업의 조건부 실행 수정

- Markdown 문서 내 사설 IP 하드코딩 검사 추가


___

### Diagram Walkthrough


```mermaid
flowchart LR
  caller["21_docs-sync.yml"]
  reusable["42_reusable-docs-sync.yml"]
  linkcheck["link-check"]
  mdlint["markdown-lint"]
  readme["readme-sync-check"]
  apidocs["api-docs-check"]
  ipcheck["private-ip-check (신규)"]
  caller -- "is_pull_request 입력" --> reusable
  reusable --> linkcheck
  reusable --> mdlint
  reusable --> readme
  reusable --> apidocs
  reusable -- "신규 작업" --> ipcheck
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>구성 변경</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>21_docs-sync.yml</strong><dd><code>호출 워크플로우에서 PR 여부 전달</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/21_docs-sync.yml

<ul><li>재사용 워크플로우 호출 시 <code>with.is_pull_request</code> 입력 추가<br> <li> 호출자 이벤트 유형을 전달하여 하위 작업이 PR을 올바르게 인식하도록 수정</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/bug/pull/159/files#diff-3d3f5ca189d8f130eef4fa86fa234e14aa1670211d5abbd6b63e848a1fb3234c">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>기능 개선</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>42_reusable-docs-sync.yml</strong><dd><code>사설 IP 검사 추가 및 PR 조건 수정</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/42_reusable-docs-sync.yml

<ul><li><code>is_pull_request</code> 불리언 입력을 추가하여 호출자의 PR 상태 수신<br> <li> <code>github.event_name</code> 참조를 <code>inputs.is_pull_request</code>로 교체<br> <li> Markdown 문서에서 RFC 1918 사설 IP를 탐지하는 <code>private-ip-check</code> 작업 추가<br> <li> 중앙 <code>jclee941/.github</code> 저장소에서 검출 스크립트를 sparse-checkout으로 가져옴</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/bug/pull/159/files#diff-64d7718cef016c48a850cd68a87492080f9f003163a2f08dca31ca9a1505946b">+61/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

