### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/workflows/20_readme-gen.yml
+++ b/.github/workflows/20_readme-gen.yml
@@ -109,6 +109,11 @@ jobs:
         if: steps.diff.outputs.changed == 'true'
         run: |
           set -eu
+          # Resolve the repo default branch for the PR base. GITHUB_REF_NAME can be
+          # a ref path on some events and is wrong for downstream repos that use
+          # `main`; the default branch is always a valid base.
+          base_branch=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || true)
+          base_branch=${base_branch:-${GITHUB_REF_NAME:-master}}
           existing=$(gh pr list --head bot/auto-readme-update --json number --jq '.[0].number')
           if [ -n "$existing" ]; then
             gh pr edit "$existing" --title "docs: auto-update README.md" --body "Automated README.md update by jclee-bot."
@@ -116,7 +121,7 @@ jobs:
             gh pr create \
               --title "docs: auto-update README.md" \
               --body "Automated README.md update by jclee-bot." \
-              --base "${GITHUB_REF_NAME}" \
+              --base "$base_branch" \
               --head bot/auto-readme-update
           fi
         env:


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `12_dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`20_readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`05_gitleaks.yml`, `06_codeql.yml`, `04_actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Bug fix


___

### **Description**
- README 자동 PR 기준 브랜치 동적 추론

- GITHUB_REF_NAME 대신 저장소 기본 브랜치 사용

- 조회 실패 시 GITHUB_REF_NAME 및 master 폴백


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PR 생성 단계"] --> B["gh repo view<br>기본 브랜치 조회"]
  B -- "성공" --> C["조회된 브랜치 사용"]
  B -- "실패" --> D["GITHUB_REF_NAME 폴백"]
  D -- "실패" --> E["master 폴백"]
  C --> F["PR --base 지정"]
  E --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>20_readme-gen.yml</strong><dd><code>README 생성 워크플로우 PR 기본 브랜치 동적 추론 수정</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/20_readme-gen.yml

<ul><li><code>gh repo view</code> 명령으로 저장소의 기본 브랜치를 동적으로 조회하도록 수정<br> <li> <code>GITHUB_REF_NAME</code>이 참조 경로이거나 하위 리포지토리의 기본 브랜치와 다를 수 있는 버그 수정<br> <li> 기본 브랜치 조회 실패 시 <code>GITHUB_REF_NAME</code>, 최종적으로 <code>master</code>를 폴백으로 사용<br> <li> PR 생성 시 <code>--base</code> 인자에 동적으로 해석된 브랜치 이름을 적용</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/bug/pull/165/files#diff-3151312623e64c1035ee16621695ce8cf19800d6f70cb01f238c4d309d518c5a">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

