### PR TITLE
docs: auto-update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Bug Bounty Automation Toolkit / 버그바운티 자동화 툴킷
 
+```markdown
 ![Node.js](https://img.shields.io/badge/Node.js-ESM-339933)
 ![Playwright](https://img.shields.io/badge/Playwright-1.60%2B-45ba4b)
 ![Go](https://img.shields.io/badge/Go-scripts-00ADD8)
@@ -7,27 +8,29 @@
 ![Security](https://img.shields.io/badge/Security-gitleaks%20%7C%20CodeQL%20%7C%20Scorecard-red)
 ![README Automation](https://img.shields.io/badge/README%20model-minimax--m2.7%20%2F%20gpt--5.5-blueviolet)
 
+# Bug Bounty Automation Toolkit / 버그바운티 자동화 툴킷
+
 ## Overview / 개요
 
 ### English
 
 Bug Bounty Automation Toolkit is a local automation workspace for authorized web security research, vulnerability-study exercises, and lab-solving workflows. The repository combines:
 
-- Node.js ESM scripts for PortSwigger/Web Security Academy style lab automation and browser-driven workflows.
-- Go helper programs for monitoring and vulnerability-hunting command orchestration.
-- GitHub Actions workflows for PR checks, security scanning, PR review automation, issue management, release automation, documentation sync, and CI auto-healing.
-- Bot-side helper scripts under `_bot-scripts/` for README generation, PR review running, repository review, secret redaction, and private IP checks.
+- **Node.js ESM scripts** for PortSwigger/Web Security Academy style lab automation and browser-driven workflows using Playwright
+- **Go helper programs** for monitoring and vulnerability-hunting command orchestration
+- **GitHub Actions workflows** (29 total) for PR checks, security scanning, PR review automation, issue management, release automation, documentation sync, and CI auto-healing
+- **Bot-side helper scripts** under `_bot-scripts/` for README generation, PR review execution, repository review, secret redaction, and private IP checks
 
 The project is designed for authorized testing only. Do not run scans, lab payloads, or automated browser actions against systems you do not own or have explicit permission to test.
 
 ### 한국어
 
-Bug Bounty Automation Toolkit은 허가된 웹 보안 연구, 취약점 학습, 실습 랩 자동화를 위한 로컬 자동화 워크스페이스입니다. 이 저장소는 다음 구성요소를 포함합니다.
+Bug Bounty Automation Toolkit은 허가된 웹 보안 연구, 취약점 학습, 실습 랩 자동화를 위한 로컬 자동화 워크스페이스입니다. 이 저장소는 다음 구성요소를 포함합니다:
 
-- PortSwigger/Web Security Academy 유형 랩 자동화와 브라우저 기반 작업을 위한 Node.js ESM 스크립트
-- 모니터링 및 취약점 헌팅 명령 오케스트레이션을 위한 Go 헬퍼 프로그램
-- PR 검사, 보안 스캔, PR 리뷰 자동화, 이슈 관리, 릴리스 자동화, 문서 동기화, CI 자동 복구를 위한 GitHub Actions 워크플로
-- README 생성, PR 리뷰 실행, 저장소 리뷰, 시크릿 마스킹, 사설 IP 검사 등을 위한 `_bot-scripts/`의 봇 보조 스크립트
+- **Node.js ESM 스크립트**: Playwright를 활용한 PortSwigger/Web Security Academy 스타일의 랩 자동화 및 브라우저 기반 워크플로
+- **Go 헬퍼 프로그램**: 모니터링 및 취약점 헌팅 명령 오케스트레이션
+- **GitHub Actions 워크플로** (29개): PR 검사, 보안 스캔, PR 리뷰 자동화, 이슈 관리, 릴리스 자동화, 문서 동기화, CI 자동 복구
+- **`_bot-scripts/`의 봇 보조 스크립트**: README 생성, PR 리뷰 실행, 저장소 리뷰, 시크릿 마스킹, 사설 IP 검사
 
 이 프로젝트는 반드시 허가된 테스트에만 사용해야 합니다. 소유하지 않았거나 명시적 허가를 받지 않은 시스템을 대상으로 스캔, 페이로드, 자동 브라우저 동작을 실행하지 마세요.
 
@@ -37,480 +40,308 @@ Bug Bounty Automation Toolkit은 허가된 웹 보안 연구, 취약점 학습, 
 
 ### English
 
-- Browser-driven lab automation using Playwright.
-- Multiple Node.js solver and batch-runner scripts for lab exploration, diagnosis, and retry workflows.
-- Go-based helper scripts currently present for hunting and monitoring:
-  - `scripts/hunt.go`
-  - `scripts/monitor.go`
-  - `scripts/lib.go`
-- Target configuration through `config/targets.json`.
-- Notes and reporting assets:
-  - `notes/phase2-checklist.md`
-  - `notes/report-template.md`
-  - `notes/vulnerability-study.md`
-- 29 GitHub Actions workflow files for repository automation.
-- Security automation with gitleaks, CodeQL, dependency review, OpenSSF Scorecard, semantic PR validation, and reusable security workflows.
-- README generation automation using `minimax-m2.7` with fallback `gpt-5.5` through CLIProxyAPI at `https://cliproxy.jclee.me/v1`.
-- Bot endpoints can be integrated through `https://bot.jclee.me`.
+- **Browser-driven lab automation** — Playwright-based lab solvers for PortSwigger Academy exercises
+- **Full reconnaissance pipeline** — Subdomain enumeration, port scanning, technology detection, nuclei scanning
+- **Diff-based monitoring** — Detect new subdomains and endpoints over time via crt.sh integration
+- **Targeted vulnerability hunting** — IDOR, SSRF, SQLi, XSS, and more category-specific scans
+- **PR automation** — Auto-assignment, semantic PR title enforcement, auto-merge, bot-assisted fixes
+- **Security scanning** — Gitleaks secrets detection, CodeQL analysis, Dependency Review, Scorecard assessment
+- **README automation** — README.md auto-generation using minimax-m2.7 / gpt-5.5 models via CLIProxyAPI
+- **CI auto-healing** — Automatic recovery from flaky or failed CI runs
+- **Documentation sync** — Cross-repo docs synchronization via reusable workflows
 
 ### 한국어
 
-- Playwright 기반 브라우저 자동화 랩 실행
-- 랩 탐색, 진단, 재시도, 배치 실행을 위한 다수의 Node.js 스크립트
-- 현재 저장소에 존재하는 Go 기반 헬퍼 스크립트:
-  - `scripts/hunt.go`
-  - `scripts/monitor.go`
-  - `scripts/lib.go`
-- `config/targets.json` 기반 타깃 설정
-- 학습 및 리포팅 문서:
-  - `notes/phase2-checklist.md`
-  - `notes/report-template.md`
-  - `notes/vulnerability-study.md`
-- 저장소 자동화를 위한 29개 GitHub Actions 워크플로 파일
-- gitleaks, CodeQL, dependency review, OpenSSF Scorecard, semantic PR 검증, 재사용 보안 워크플로를 포함한 보안 자동화
-- CLIProxyAPI의 `https://cliproxy.jclee.me/v1`을 통해 `minimax-m2.7` 모델을 기본으로 사용하고 `gpt-5.5`를 fallback으로 사용하는 README 생성 자동화
-- `https://bot.jclee.me` 기반 봇 엔드포인트 연동 가능
+- **브라우저 기반 랩 자동화** — PortSwigger Academy 연습问题的 Playwright 기반 랩 솔버
+- **완전한 정찰 파이프라인** — 서브도메인 열거, 포트 스캔, 기술 탐지, nuclei 스캔
+- **차분 기반 모니터링** — crt.sh 통합을 통한 새로운 서브도메인 및 엔드포인트 감지
+- **타겟 취약점 헌팅** — IDOR, SSRF, SQLi, XSS 등 카테고리별 스캔
+- **PR 자동화** — 자동 할당, 시맨틱 PR 제목 enforcement, 자동 병합, 봇 보조 수정
+- **보안 스캔** — Gitleaks 시크릿 탐지, CodeQL 분석, Dependency Review, Scorecard 평가
+- **README 자동화** — CLIProxyAPI를 통한 minimax-m2.7 / gpt-5.5 모델 사용 README.md 자동 생성
+- **CI 자동 복구** — 불안정하거나 실패한 CI 실행의 자동 복구
+- **문서 동기화** — 재사용 가능한 워크플로를 통한 크로스-레포 문서 동기화
 
 ---
 
 ## Architecture / 아키텍처
 
 ```mermaid
-flowchart TD
-    A[Developer / Researcher] --> B[Local Workspace]
-    B --> C[Node.js ESM Scripts]
-    B --> D[Go Helper Scripts]
-    B --> E[Config and Notes]
+flowchart TB
+    subgraph Local["Local Environment / 로컬 환경"]
+        subgraph Scripts["Node.js / Go Scripts / 스크립트"]
+            LAB["lab-runner.mjs<br>lab-solver.mjs<br>lab-gap-solver.mjs"]
+            RECON["recon.go<br>monitor.go<br>hunt.go"]
+            SETUP["setup.go<br>lib.go"]
+        end
+        NOTES["notes/<br>report-template.md<br>phase2-checklist.md"]
+        CONFIG["config/targets.json"]
+    end
 
-    C --> C1[Playwright Browser Automation]
-    C --> C2[Lab Solvers]
-    C --> C3[Batch Runners]
-    C --> C4[Diagnostics and Progress Checks]
+    subgraph GitHub["GitHub Platform / GitHub 플랫폼"]
+        subgraph Workflows["GitHub Actions Workflows / 워크플로"]
+            PR_CHKS["03_pr-checks.yml<br>44_reusable-pr-checks.yml"]
+            SEC_SCAN["05_gitleaks.yml<br>06_codeql.yml<br>07_dependency-review.yml<br>08_scorecard.yml<br>45_reusable-gitleaks.yml"]
+            PR_REV["10_pr-review.yml<br>security/11_pr-review.yml"]
+            AUTOMERGE["12_dependabot-auto-merge.yml<br>13_pr-auto-merge.yml"]
+            ISSUE_MGMT["18_issue-management.yml<br>19_issue-backfill.yml<br>43_reusable-issue-management.yml"]
+            DOCS["21_docs-sync.yml<br>42_reusable-docs-sync.yml"]
+            RELEASE["24_release-notes.yml<br>25_release-publish.yml"]
+            CI_HEAL["60_ci-auto-heal.yml<br>29_downstream-health-check.yml"]
+            BRANCHES["01_branch-to-pr.yml<br>02_issue-to-branch.yml"]
+            CI_FAIL["37_ci-failure-issues.yml"]
+            OTHER["04_actionlint.yml<br>09_semantic-pr.yml<br>14_bot-auto-fix.yml<br>15_merged-pr-cleanup.yml<br>20_readme-gen.yml"]
+        end
 
-    D --> D1[hunt.go]
-    D --> D2[monitor.go]
-    D --> D3[lib.go]
+        subgraph BotScripts["_bot-scripts/ (GitHub Actions Runner)"]
+            README_GEN["generate_readme.py"]
+            PR_RUNNER["pr_review_runner.py"]
+            REPO_REV["repo_review.py"]
+            REDACT["redact_exposed_secrets.py"]
+            CHECKS["check_private_ips.py<br>check_workflow_scripts.py<br>check_hardcode_scan_patterns_test.py"]
+        end
+    end
 
-    E --> E1[config/targets.json]
-    E --> E2[notes/report-template.md]
-    E --> E3[notes/vulnerability-study.md]
+    subgraph External["External Services / 외부 서비스"]
+        CLIPROXY["CLIProxyAPI<br>cliproxy.jclee.me"]
+        PORTSWIGGER["PortSwigger Academy<br>labs.googleapis.com"]
+        CRT_SH["crt.sh"]
+        DISCORD["Discord Webhook"]
+    end
 
-    F[GitHub Repository] --> G[GitHub Actions]
-    G --> G1[PR Checks]
-    G --> G2[Security Scans]
-    G --> G3[PR Review Automation]
-    G --> G4[Issue Management]
-    G --> G5[Docs and README Generation]
-    G --> G6[Release Automation]
-    G --> G7[CI Auto-Healing]
+    LAB --> PORTSWIGGER
+    RECON --> CRT_SH
+    MONITOR --> DISCORD
+    REFRESH["20_readme-gen.yml"] --> CLIPROXY
+    PR_RUNNER --> CLIPROXY
+    10_pr-review.yml --> CLIPROXY
 
-    H[_bot-scripts] --> H1[generate_readme.py]
-    H --> H2[pr_review_runner.py]
-    H --> H3[repo_review.py]
-    H --> H4[check_private_ips.py]
-    H --> H5[redact_exposed_secrets.py]
-
-    G5 --> I[CLIProxyAPI]
-    I --> I1[minimax-m2.7]
-    I --> I2[gpt-5.5 fallback]
-    I --> I3[https://cliproxy.jclee.me/v1]
-
-    G3 --> J[PR Review Services]
-    J --> J1[qodo-ai/pr-agent]
-    J --> J2[https://bot.jclee.me]
-```
-
----
-
-## Repository Structure / 저장소 구조
-
-```text
-/
-├── AGENTS.md
-├── CONTRIBUTING.md
-├── LICENSE
-├── Makefile
-├── README.md
-├── interactsh_payload.txt
-├── output-lab08.png
-├── package-lock.json
-├── package.json
-├── _bot-scripts/
-│   ├── AGENTS.md
-│   ├── CODE_OF_CONDUCT.md
-│   ├── CONTRIBUTING.md
-│   ├── Dockerfile.github_action
-│   ├── Dockerfile.github_app
-│   ├── LICENSE
-│   ├── MANIFEST.in
-│   ├── Makefile
-│   ├── NOTICE
-│   ├── README.md
-│   ├── SECURITY.md
-│   ├── docker-compose.github_app.yml
-│   ├── docker-compose.github_app.yml.lxc
-│   ├── filebeat.yml
-│   ├── pyproject.toml
-│   ├── requirements-dev.txt
-│   ├── requirements.txt
-│   ├── setup.py
-│   └── scripts/
-├── notes/
-│   ├── phase2-checklist.md
-│   ├── report-template.md
-│   └── vulnerability-study.md
-├── config/
-│   └── targets.json
-└── scripts/
-    ├── *.cjs
-    ├── *.mjs
-    ├── *.go
-    └── *.sh
+    style Local fill:#f9f,stroke:#333,stroke-width:2px
+    style GitHub fill:#bbf,stroke:#333,stroke-width:2px
+    style External fill:#bfb,stroke:#333,stroke-width:2px
 ```
 
 ---
 
 ## Automation Inventory / 자동화 인벤토리
 
-### GitHub Actions Workflows / GitHub Actions 워크플로
+### GitHub Actions Workflows (29 total) / GitHub Actions 워크플로 (29개)
 
-The repository contains 29 workflow files.
+| File / 파일 | Purpose / 목적 |
+|-------------|----------------|
+| `01_branch-to-pr.yml` | Create PR from branch, link branch to PR |
+| `02_issue-to-branch.yml` | Create branch from issue, track issue in branch |
+| `03_pr-checks.yml` | Run PR checks (lint, test, build) |
+| `04_actionlint.yml` | Lint all workflow files with actionlint |
+| `05_gitleaks.yml` | Scan for secrets in commits and PRs |
+| `06_codeql.yml` | Run CodeQL security analysis |
+| `07_dependency-review.yml` | Review dependency changes for vulnerabilities |
+| `08_scorecard.yml` | Run OpenSSF Scorecard security assessment |
+| `09_semantic-pr.yml` | Enforce semantic PR title format |
+| `10_pr-review.yml` | Auto PR review using CLIProxyAPI |
+| `12_dependabot-auto-merge.yml` | Auto-merge Dependabot PRs |
+| `13_pr-auto-merge.yml` | Auto-merge PRs meeting criteria |
+| `14_bot-auto-fix.yml` | Apply bot-generated fixes automatically |
+| `15_merged-pr-cleanup.yml` | Cleanup after PR merge |
+| `18_issue-management.yml` | Issue labeling and management |
+| `19_issue-backfill.yml` | Backfill issue metadata |
+| `20_readme-gen.yml` | Auto-generate README via minimax-m2.7 / gpt-5.5 |
+| `21_docs-sync.yml` | Sync documentation across repos |
+| `24_release-notes.yml` | Generate release notes |
+| `25_release-publish.yml` | Publish releases |
+| `29_downstream-health-check.yml` | Check downstream project health |
+| `37_ci-failure-issues.yml` | Create issue on CI failure |
+| `42_reusable-docs-sync.yml` | Reusable workflow for docs sync |
+| `43_reusable-issue-management.yml` | Reusable workflow for issue mgmt |
+| `44_reusable-pr-checks.yml` | Reusable workflow for PR checks |
+| `45_reusable-gitleaks.yml` | Reusable workflow for secrets scanning |
+| `60_ci-auto-heal.yml` | Auto-heal failing CI runs |
+| `ci.yml` | Main CI workflow |
+| `security/11_pr-review.yml` | Security-focused PR review |
 
-이 저장소에는 29개의 워크플로 파일이 있습니다.
+### Bot-side Helper Scripts / 봇 보조 스크립트 (`_bot-scripts/`)
 
-| File | Purpose |
-|---|---|
-| `01_branch-to-pr.yml` | Branch-to-PR automation |
-| `02_issue-to-branch.yml` | Issue-to-branch automation |
-| `03_pr-checks.yml` | Pull request validation checks |
-| `04_actionlint.yml` | GitHub Actions workflow linting |
-| `05_gitleaks.yml` | Secret scanning with gitleaks |
-| `06_codeql.yml` | CodeQL static analysis |
-| `07_dependency-review.yml` | Dependency review for PRs |
-| `08_scorecard.yml` | OpenSSF Scorecard security posture checks |
-| `09_semantic-pr.yml` | Semantic pull request title validation |
-| `10_pr-review.yml` | Automated PR review workflow |
-| `12_dependabot-auto-merge.yml` | Dependabot auto-merge automation |
-| `13_pr-auto-merge.yml` | PR auto-merge automation |
-| `14_bot-auto-fix.yml` | Bot-driven auto-fix workflow |
-| `15_merged-pr-cleanup.yml` | Cleanup after merged pull requests |
-| `18_issue-management.yml` | Issue labeling, triage, or lifecycle management |
-| `19_issue-backfill.yml` | Issue metadata backfill automation |
-| `20_readme-gen.yml` | README generation automation |
-| `21_docs-sync.yml` | Documentation synchronization |
-| `24_release-notes.yml` | Release notes generation |
-| `25_release-publish.yml` | Release publishing automation |
-| `29_downstream-health-check.yml` | Downstream health checks |
-| `37_ci-failure-issues.yml` | Create or manage issues for CI failures |
-| `42_reusable-docs-sync.yml` | Reusable documentation sync workflow |
-| `43_reusable-issue-management.yml` | Reusable issue management workflow |
-| `44_reusable-pr-checks.yml` | Reusable PR checks workflow |
-| `45_reusable-gitleaks.yml` | Reusable gitleaks workflow |
-| `60_ci-auto-heal.yml` | CI auto-healing workflow |
-| `ci.yml` | General CI workflow |
-| `security/11_pr-review.yml` | Security-scoped PR review workflow |
-
-### Bot and Repository Automation Tools / 봇 및 저장소 자동화 도구
-
-| Tool | Location | Purpose |
-|---|---|---|
-| `generate_readme.py` | `_bot-scripts/scripts/generate_readme.py` | Generates or refreshes README content |
-| `pr_review_runner.py` | `_bot-scripts/scripts/pr_review_runner.py` | Runs automated PR review logic |
-| `repo_review.py` | `_bot-scripts/scripts/repo_review.py` | Repository-level review helper |
-| `check_private_ips.py` | `_bot-scripts/scripts/check_private_ips.py` | Detects hardcoded private/internal IP patterns |
-| `check_private_ips_test.py` | `_bot-scripts/scripts/check_private_ips_test.py` | Tests for private IP detection |
-| `pr_review_runner_test.py` | `_bot-scripts/scripts/pr_review_runner_test.py` | Tests for PR review runner behavior |
-| `redact_exposed_secrets.py` | `_bot-scripts/scripts/redact_exposed_secrets.py` | Redacts exposed secret-like values |
-| `Dockerfile.github_action` | `_bot-scripts/Dockerfile.github_action` | Container image for GitHub Action execution |
-| `Dockerfile.github_app` | `_bot-scripts/Dockerfile.github_app` | Container image for GitHub App execution |
-
-### Local Node.js Automation Scripts / 로컬 Node.js 자동화 스크립트
-
-| Category | Scripts |
-|---|---|
-| Lab runners | `lab-runner.mjs`, `lab-runner-aggressive.mjs`, `lab-batch-fast.mjs`, `lab-batch-slow.mjs`, `lab-batch-oob.mjs`, `lab-batch-smuggling.mjs`, `lab-batch-solver.mjs` |
-| Lab solvers | `lab-solver.mjs`, `lab-gap-solver.mjs`, `lab-gap-helpers.mjs`, `auth-solver.cjs`, `essential-skills-solver.cjs`, `llm-attacks-solver.cjs`, `oob-solver.cjs`, `master-solver.cjs`, `comprehensive-solver.cjs` |
-| Batch automation | `batch-a.cjs`, `batch-b.cjs`, `batch-b-fixed.cjs`, `batch-c.cjs`, `batch-collab.cjs`, `batch-d.cjs`, `batch-remaining.cjs`, `batch1-solver.cjs`, `comprehensive-batch.cjs`, `custom-batch2.cjs`, `custom-easy-solver.cjs`, `focused-batch.cjs` |
-| Diagnostics | `diagnose-access.cjs`, `diagnose-access2.cjs`, `diagnose-deser.cjs`, `diagnose-essential.cjs`, `diagnose-essential2.cjs`, `diagnose-essential3.cjs`, `diagnose-nav.cjs`, `diagnose-topics.cjs` |
-| Exploration and listing | `explore-essential.cjs`, `explore-essential2.cjs`, `explore-essential3.cjs`, `explore-race.cjs`, `list-essential.cjs`, `list-race.cjs`, `extract-labs.cjs` |
-| Progress and forms | `check-form.cjs`, `check-progress.cjs`, `get-lab-urls.cjs`, `get-lab-urls2.cjs`, `get-lab-urls.sh` |
-| Retry and finalization | `extended-retry.cjs`, `final-attempt.cjs` |
-| OOB support | `interactsh-wrapper.sh` |
-
-### Local Go Scripts / 로컬 Go 스크립트
-
-| Script | Purpose |
-|---|---|
-| `scripts/hunt.go` | Targeted vulnerability hunting helper |
-| `scripts/monitor.go` | Monitoring helper for target changes or findings |
-| `scripts/lib.go` | Shared Go helper functions used by Go programs |
-
-### Go Automation Tools / Go 자동화 도구
-
-The provided inventory reports 0 standalone Go automation tools. The repository does contain Go scripts in `scripts/`, but they are not listed as separate packaged automation tools.
-
-제공된 인벤토리 기준 독립 Go 자동화 도구 수는 0개입니다. 다만 `scripts/` 아래에 Go 스크립트는 존재하며, 별도 패키징된 자동화 도구로 집계되지는 않았습니다.
+| Script / 스크립트 | Purpose / 목적 |
+|-------------------|----------------|
+| `generate_readme.py` | Generate README.md using LLM models |
+| `pr_review_runner.py` | Execute PR review workflow |
+| `repo_review.py` | Review repository for issues |
+| `redact_exposed_secrets.py` | Redact exposed secrets from logs |
+| `check_private_ips.py` | Check for hardcoded private IPs |
+| `check_workflow_scripts.py` | Validate workflow script references |
+| `check_hardcode_scan_patterns_test.py` | Scan for hardcoded scan patterns |
 
 ---
 
 ## Quick Start / 빠른 시작
 
-### 1. Prerequisites / 사전 요구사항
-
-Install the following locally:
-
-다음을 로컬 환경에 설치하세요.
-
-- Node.js 20 or later
-- npm
-- Go, if running Go helper scripts
-- Git
-- Playwright browser dependencies
-
-### 2. Install dependencies / 의존성 설치
+### English
 
 ```bash
-npm install
-npx playwright install
+# Clone the repository
+git clone https://github.com/jclee941/.github
+cd bug
+
+# First-time setup
+make setup
+
+# Run reconnaissance on a target
+make recon TARGET=example.com
+
+# Monitor for changes
+make monitor TARGET=example.com
+
+# Hunt vulnerabilities
+make hunt TARGET=example.com
+
+# Full scan (recon + hunt)
+make full-scan TARGET=example.com
 ```
 
-### 3. Review target configuration / 타깃 설정 확인
+### 한국어
 
 ```bash
-cat config/targets.json
+# 레포지토리 클론
+git clone https://github.com/jclee941/.github
+cd bug
+
+# 최초 설정
+make setup
+
+# 타겟 정찰 실행
+make recon TARGET=example.com
+
+# 변경 사항 모니터링
+make monitor TARGET=example.com
+
+# 취약점 헌팅
+make hunt TARGET=example.com
+
+# 전체 스캔 (정찰 + 헌팅)
+make full-scan TARGET=example.com
 ```
-
-Use placeholders and authorized targets only. Do not hardcode private infrastructure addresses or sensitive internal endpoints.
-
-허가된 타깃만 설정하세요. 사설 인프라 주소나 민감한 내부 엔드포인트를 하드코딩하지 마세요.
-
-Example placeholder style:
-
-```json
-{
-  "targets": [
-    {
-      "name": "authorized-program",
-      "domain": "example.com",
-      "notes": "Replace with an explicitly authorized target."
-    }
-  ]
-}
-```
-
-### 4. Run a lab automation script / 랩 자동화 스크립트 실행
-
-```bash
-node scripts/lab-runner.mjs
-```
-
-For targeted scripts:
-
-```bash
-node scripts/lab-solver.mjs
-node scripts/lab-gap-solver.mjs
-node scripts/check-progress.cjs
-```
-
-### 5. Run Go helpers / Go 헬퍼 실행
-
-```bash
-go run scripts/monitor.go scripts/lib.go
-go run scripts/hunt.go scripts/lib.go
-```
-
-Some Makefile targets reference Go files that are not present in the provided top-level script listing, such as `scripts/setup.go` and `scripts/recon.go`. If you intend to use those targets, verify that the required files exist in your checkout or restore them before running the commands.
-
-제공된 스크립트 목록 기준으로 `scripts/setup.go`, `scripts/recon.go`는 존재하지 않지만 Makefile 일부 타깃에서 참조됩니다. 해당 타깃을 사용할 경우 먼저 파일 존재 여부를 확인하거나 복구하세요.
 
 ---
 
 ## Local Development / 로컬 개발
 
-### Node.js development / Node.js 개발
-
-The package is configured as an ES module project.
-
-패키지는 ESM 프로젝트로 설정되어 있습니다.
-
-```json
-{
-  "type": "module",
-  "main": "scripts/lab-runner.mjs"
-}
-```
-
-Common local workflow:
-
-일반적인 로컬 작업 흐름:
-
-```bash
-npm install
-npx playwright install
-node scripts/lab-runner.mjs
-```
-
-The current `npm test` script is a placeholder and exits with an error:
-
-현재 `npm test`는 placeholder이며 오류로 종료됩니다.
-
-```bash
-npm test
-```
-
-Expected behavior:
-
-```text
-Error: no test specified
-```
-
-### Python bot script development / Python 봇 스크립트 개발
-
-Bot-side scripts live under `_bot-scripts/`.
-
-봇 관련 스크립트는 `_bot-scripts/` 아래에 있습니다.
-
-```bash
-cd _bot-scripts
-python -m venv .venv
-. .venv/bin/activate
-pip install -r requirements.txt -r requirements-dev.txt
-```
-
-Useful scripts:
-
-유용한 스크립트:
-
-```bash
-python scripts/check_private_ips.py
-python scripts/redact_exposed_secrets.py
-python scripts/generate_readme.py
-python scripts/repo_review.py
-```
-
-### README generation / README 생성
-
-README automation is represented by:
-
-README 자동화는 다음 구성요소로 표현됩니다.
-
-- Workflow: `20_readme-gen.yml`
-- Tool: `_bot-scripts/scripts/generate_readme.py`
-- Primary model: `minimax-m2.7`
-- Fallback model: `gpt-5.5`
-- API endpoint: `https://cliproxy.jclee.me/v1`
-
-### PR review automation / PR 리뷰 자동화
-
-PR review automation is represented by:
-
-PR 리뷰 자동화는 다음 구성요소로 표현됩니다.
-
-- Workflow: `10_pr-review.yml`
-- Security workflow: `security/11_pr-review.yml`
-- Tool: `_bot-scripts/scripts/pr_review_runner.py`
-- Supported integration reference: `qodo-ai/pr-agent`
-- Bot endpoint reference: `https://bot.jclee.me`
-
----
-
-## Commands Reference / 명령어 레퍼런스
-
-### Makefile targets / Makefile 타깃
-
-The Makefile defines the following commands. Some targets may depend on scripts that are not present in the provided project tree, so check file availability before use.
-
-Makefile에는 다음 명령어가 정의되어 있습니다. 일부 타깃은 제공된 프로젝트 트리에 없는 스크립트에 의존할 수 있으므로 실행 전 파일 존재 여부를 확인하세요.
-
-| Command | Description |
-|---|---|
-| `make help` | Show available commands |
-| `make setup` | Initial setup; verifies tools and downloads wordlists if supporting script exists |
-| `make recon TARGET=example.com` | Run full recon pipeline on an authorized target |
-| `make recon-fast TARGET=example.com` | Run quick recon without nuclei if supporting script exists |
-| `make monitor TARGET=example.com` | Run diff-style monitoring |
-| `make hunt TARGET=example.com` | Run targeted vulnerability hunting |
-| `make hunt-idor TARGET=example.com` | Hunt IDOR issues only |
-| `make hunt-ssrf TARGET=example.com` | Hunt SSRF issues only |
-| `make full-scan TARGET=example.com` | Run combined recon and hunting workflow if all supporting scripts exist |
-| `make clean` | Remove generated scan output if implemented in the full Makefile |
-
-### Node.js commands / Node.js 명령어
-
-```bash
-npm install
-npx playwright install
-node scripts/lab-runner.mjs
-node scripts/lab-solver.mjs
-node scripts/lab-gap-solver.mjs
-node scripts/check-progress.cjs
-node scripts/get-lab-urls.cjs
-```
-
-### Go commands / Go 명령어
-
-```bash
-go run scripts/monitor.go scripts/lib.go
-go run scripts/hunt.go scripts/lib.go
-```
-
-### Shell helpers / Shell 헬퍼
-
-```bash
-bash scripts/get-lab-urls.sh
-bash scripts/interactsh-wrapper.sh
-```
-
-### Bot script commands / 봇 스크립트 명령어
-
-```bash
-cd _bot-scripts
-python scripts/check_private_ips.py
-python scripts/redact_exposed_secrets.py
-python scripts/generate_readme.py
-python scripts/pr_review_runner.py
-python scripts/repo_review.py
-```
-
----
-
-## Security and Responsible Use / 보안 및 책임 있는 사용
-
 ### English
 
-Use this toolkit only for:
+#### Prerequisites
 
-- Systems you own.
-- Lab environments.
-- Bug bounty programs where the target is explicitly in scope.
-- Internal security testing with written authorization.
+- Go 1.21+
+- Node.js 18+
+- Playwright browsers (`npx playwright install`)
+- Tools: nmap, subfinder, assetfinder, naabu, nuclei, httpx
 
-Do not use this toolkit for:
+#### Repository Structure
 
-- Unauthorized scanning.
-- Credential theft.
-- Persistence.
-- Exploitation of third-party systems outside scope.
-- Exfiltration of data.
-- Bypassing rate limits or program rules.
+```
+bug/
+├── Makefile                 # Orchestration commands
+├── package.json             # Node.js dependencies
+├── config/
+│   └── targets.json         # Target configuration
+├── scripts/                  # Go helper programs
+│   ├── setup.go
+│   ├── recon.go
+│   ├── monitor.go
+│   ├── hunt.go
+│   ├── lib.go
+│   └── *.mjs               # Node.js lab solvers
+├── notes/                   # Learning notes & templates
+├── _bot-scripts/            # Bot helper scripts (CI runner)
+│   ├── scripts/
+│   │   ├── generate_readme.py
+│   │   ├── pr_review_runner.py
+│   │   └── ...
+│   └── pyproject.toml
+└── .github/
+    └── workflows/          # 29 workflow files
+```
+
+#### Environment Variables
+
+| Variable / 변수 | Description / 설명 |
+|-----------------|-------------------|
+| `CLIPROXY_API_KEY` | API key for CLIProxyAPI (cliproxy.jclee.me) |
+| `DISCORD_WEBHOOK` | Discord webhook for alerts |
+| `GITHUB_TOKEN` | GitHub token for API access |
 
 ### 한국어
 
-이 툴킷은 다음 경우에만 사용하세요.
+#### 전제 조건
 
-- 본인이 소유한 시스템
-- 실습 환경
-- 명시적으로 scope에 포함된 버그바운티 프로그램
-- 서면 허가를 받은 내부 보안 테스트
+- Go 1.21+
+- Node.js 18+
+- Playwright 브라우저 (`npx playwright install`)
+- 도구: nmap, subfinder, assetfinder, naabu, nuclei, httpx
 
-다음 용도로 사용하지 마세요.
+#### 저장소 구조
 
-- 무단 스캔
-- 자격 증명 탈취
-- 지속성 확보
-- scope 밖의 제3자 시스템 악용
-- 데이터 유출
-- rate limit 또는 프로그램 규칙 우회
+```
+bug/
+├── Makefile                 # 오케스트레이션 명령
+├── package.json             # Node.js 종속성
+├── config/
+│   └── targets.json         # 타겟 설정
+├── scripts/                  # Go 헬퍼 프로그램
+│   ├── setup.go
+│   ├── recon.go
+│   ├── monitor.go
+│   ├── hunt.go
+│   ├── lib.go
+│   └── *.mjs               # Node.js 랩 솔버
+├── notes/                   # 학습 노트 및 템플릿
+├── _bot-scripts/            # CI 러너의 봇 보조 스크립트
+│   ├── scripts/
+│   │   ├── generate_readme.py
+│   │   ├── pr_review_runner.py
+│   │   └── ...
+│   └── pyproject.toml
+└── .github/
+    └── workflows/          # 29개의 워크플로 파일
+```
+
+---
+
+## Commands Reference / 명령어 참고
+
+### English
+
+Run `make help` to see all available commands:
+
+| Command / 명령 | Description / 설명 |
+|----------------|-------------------|
+| `make help` | Show all available commands |
+| `make setup` | First-time setup — verify tools, download wordlists |
+| `make recon TARGET=x.com` | Full recon pipeline |
+| `make recon-fast TARGET=x.com` | Recon without nuclei scan |
+| `make monitor TARGET=x.com` | Diff-based change detection |
+| `make hunt TARGET=x.com` | All vulnerability categories |
+| `make hunt-idor TARGET=x.com` | IDOR vulnerabilities only |
+| `make hunt-ssrf TARGET=x.com` | SSRF vulnerabilities only |
+| `make hunt-sqli TARGET=x.com` | SQL injection only |
+| `make full-scan TARGET=x.com` | Recon + hunt combined |
+| `make clean` | Remove scan results |
+
+### 한국어
+
+`make help`를 실행하여 모든 사용 가능한 명령을 확인하세요:
+
+| 명령 | 설명 |
+|------|------|
+| `make help` | 모든 사용 가능한 명령 표시 |
+| `make setup` | 최초 설정 — 도구 확인, 워드리스트 다운로드 |
+| `make recon TARGET=x.com` | 전체 정찰 파이프라인 |
+| `make recon-fast TARGET=x.com` | nuclei 스캔 없이 정찰 |
+| `make monitor TARGET=x.com` | 차분 기반 변경 감지 |
+| `make hunt TARGET=x.com` | 모든 취약점 카테고리 |
+| `make hunt-idor TARGET=x.com` | IDOR 취약점만 |
+| `make hunt-ssrf TARGET=x.com` | SSRF 취약점만 |
+| `make hunt-sqli TARGET=x.com` | SQL 인젝션만 |
+| `make full-scan TARGET=x.com` | 정찰 + 헌팅 combined |
+| `make clean` | 스캔 결과 삭제 |
 
 ---
 
@@ -518,48 +349,75 @@ Do not use this toolkit for:
 
 ### English
 
-1. Read `CONTRIBUTING.md`.
-2. Create a branch for your change.
-3. Keep automation changes small and reviewable.
-4. Update documentation when adding or changing scripts.
-5. Do not commit scan results, credentials, tokens, cookies, private keys, or environment-specific secrets.
-6. Use placeholders such as `<homelab-host>` or `<homelab-elk>` for local infrastructure references.
-7. Run relevant local checks before opening a PR.
-8. Ensure PR titles follow the semantic PR requirements enforced by `09_semantic-pr.yml`.
+Contributions are welcome. Please read [CONTRIBUTING.md](./CONTRIBUTING.md) for details.
 
-Recommended PR checklist:
+#### Workflow Addition Process
 
-- [ ] The change is authorized and safe.
-- [ ] Scripts have clear names and usage comments.
-- [ ] New automation is documented in this README.
-- [ ] No secrets or private infrastructure details are committed.
-- [ ] Workflow file names are referenced exactly as they exist on disk.
-- [ ] Security-sensitive behavior has guardrails or explicit warnings.
+1. Add workflow file to `.github/workflows/` with numeric prefix
+2. Update this README's automation inventory section
+3. Run `04_actionlint.yml` to validate workflow syntax
+4. Test in a sandbox environment before merge
+
+#### Bot Script Addition Process
+
+1. Add script to `_bot-scripts/scripts/`
+2. Ensure it has proper error handling and logging
+3. Add unit tests (`*_test.py`)
+4. Update `_bot-scripts/AGENTS.md` if applicable
+
+#### Conventions
+
+- All Go scripts are standalone — run via `go run scripts/x.go`
+- Use only Go stdlib (no external dependencies)
+- Results stored in timestamped directories under `recon/`
+- Never commit scan results, targets, or reports directories
 
 ### 한국어
 
-1. `CONTRIBUTING.md`를 먼저 읽어주세요.
-2. 변경사항용 브랜치를 생성하세요.
-3. 자동화 변경은 작고 리뷰 가능하게 유지하세요.
-4. 스크립트를 추가하거나 변경하면 문서도 함께 업데이트하세요.
-5. 스캔 결과, 자격 증명, 토큰, 쿠키, 개인 키, 환경별 시크릿을 커밋하지 마세요.
-6. 로컬 인프라 참조에는 `<homelab-host>`, `<homelab-elk>` 같은 placeholder를 사용하세요.
-7. PR 생성 전에 관련 로컬 검사를 실행하세요.
-8. PR 제목은 `09_semantic-pr.yml`에서 검사하는 semantic PR 규칙을 따르세요.
+기여를 환영합니다. 자세한 내용은 [CONTRIBUTING.md](./CONTRIBUTING.md)를 읽어주세요.
 
-권장 PR 체크리스트:
+#### 워크플로 추가 절차
 
-- [ ] 변경사항이 허가된 범위이며 안전합니다.
-- [ ] 스크립트 이름과 사용법이 명확합니다.
-- [ ] 새로운 자동화가 README에 문서화되었습니다.
-- [ ] 시크릿 또는 사설 인프라 정보가 커밋되지 않았습니다.
-- [ ] 워크플로 파일명은 실제 디스크상의 이름과 정확히 일치합니다.
-- [ ] 보안에 민감한 동작에는 보호장치 또는 명시적 경고가 있습니다.
+1. 숫자 접두사와 함께 `.github/workflows/`에 워크플로 파일 추가
+2. 이 README의 자동화 인벤토리 섹션 업데이트
+3. `04_actionlint.yml`를 실행하여 워크플로 구문 검증
+4. 머지 전 샌드박스 환경에서 테스트
+
+#### 봇 스크립트 추가 절차
+
+1. `_bot-scripts/scripts/`에 스크립트 추가
+2. 적절한 오류 처리 및 로깅 포함
+3. 단위 테스트 추가 (`*_test.py`)
+4. 해당되는 경우 `_bot-scripts/AGENTS.md` 업데이트
+
+#### conventions
+
+- 모든 Go 스크립트는 독립형 — `go run scripts/x.go`로 실행
+- Go 표준 라이브러리만 사용 (외부 종속성 없음)
+- 결과는 `recon/` 아래의 타임스탬프 디렉토리에 저장
+- 스캔 결과, 타겟, 보고서 디렉토리 절대 커밋하지 않기
+
+---
+
+## External Integrations / 외부 통합
+
+| Service / 서비스 | Endpoint / 엔드포인트 | Purpose / 목적 |
+|-----------------|----------------------|----------------|
+| CLIProxyAPI | `https://cliproxy.jclee.me/v1` | LLM-based PR review and README generation |
+| PortSwigger Academy | `labs.googleapis.com` | Lab automation targets |
+| crt.sh | `crt.sh` | Certificate transparency subdomain enumeration |
+| Discord | Webhook configured in `config/targets.json` | Alert notifications |
 
 ---
 
 ## License / 라이선스
 
-See `LICENSE`.
+See [LICENSE](./LICENSE) for details.
 
-자세한 내용은 `LICENSE` 파일을 확인하세요.
+---
+
+## Contact / 연락처
+
+- GitHub Issues: <https://github.com/jclee941/bug/issues>
+- Bot Interface: <https://bot.jclee.me>
+- PR-Agent: <https://github.com/qodo-ai/pr-agent>


### PR DESCRIPTION
### **User description**
Automated README.md update by jclee-bot.


___

### **PR Type**
documentation, enhancement


___

### **Description**
- README.md 구조 전체를 재편하여 가독성과 정보 접근성 향상

- 아키텍처 다이어그램을 TB 레이아웃으로 재설계하고 상세 내용刷新

- Quick Start 가이드를 make 명령어 중심으로 간소화

- 자동화 인벤토리 테이블 형식 통일 및 항목 정리

- 외부 통합 서비스 및 연락처 정보 등 새로운 섹션 추가


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[README.md] --> B[구조 재편]
  A --> C[콘텐츠 업데이트]
  B --> B1[개요 섹션 bold 형식 통일]
  B --> B2[자동화 인벤토리 테이블 재구성]
  B --> B3[명령어 레퍼런스 간소화]
  C --> C1[배지 추가 6종]
  C --> C2[아키텍처 다이어그램 redesign]
  C --> C3[Quick Start make 명령어 중심]
  C --> C4[외부 통합/연락처 섹션 신규 추가]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>README.md comprehensive restructure and content refresh</code>&nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>상단 배지 6종 추가 (Node.js, Playwright, Go, GitHub Actions, Security, README <br>Automation)<br> <li> Overview/개요 섹션을 **bold** 마크다운 형식으로 통일하여 가독성 개선<br> <li> 아키텍처 다이어그램을 TD에서 TB 레이아웃으로 전면 재설계<br> <li> Quick Start 가이드를 make 기반 명령어로 일원화<br> <li> Local Development 섹션 구조화 및 환경 변수 테이블 추가<br> <li> 자동화 인벤토리 테이블 형식 통일 (GitHub Actions 워크플로 29개, 봇 스크립트 목록)<br> <li> Commands Reference를 make help 출력 중심으로 간소화<br> <li> Contribution Guide에 워크플로/봇 스크립트 추가 절차 명시<br> <li> 외부 통합 서비스 (CLIProxyAPI, PortSwigger Academy, crt.sh, Discord) 섹션 신규 추가<br> <li> Contact/연락처 섹션 추가</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/bug/pull/168/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+302/-444</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

