### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/workflows/37_ci-failure-issues.yml
+++ b/.github/workflows/37_ci-failure-issues.yml
@@ -98,8 +98,14 @@ jobs:
             echo "::error::Invalid conclusion: $CONCLUSION (must be success, failure, cancelled, or skipped)"
             exit 1
           fi
-          # For cancelled/skipped, treat as failure for issue creation purposes
-          if [[ "$CONCLUSION" == "cancelled" || "$CONCLUSION" == "skipped" ]]; then
+          # 'skipped' is NOT a failure: workflows like CI Auto-Heal have
+          # `if: ... conclusion == 'failure'` and legitimately skip when upstream
+          # succeeded. Treat it like success (close stale issues, create none).
+          if [[ "$CONCLUSION" == "skipped" ]]; then
+            CONCLUSION="success"
+          fi
+          # A cancelled run is treated as a failure for issue-creation purposes.
+          if [[ "$CONCLUSION" == "cancelled" ]]; then
             CONCLUSION="failure"
           fi
 


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `12_dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`20_readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`05_gitleaks.yml`, `06_codeql.yml`, `04_actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Bug fix


___

### **Description**
- CI 실패 이슈 워크플로우에서 'skipped' 결과를 실패가 아닌 성공으로 처리하도록 수정

- 'skipped'는 CI Auto-Heal과 같이 상위 워크플로우 성공 시 의도적으로 건너뛰는 워크플로우를 위한 것으로, 잘못된 이슈 생성 방지

- 'cancelled'runs는 여전히 실패로 처리되어 이슈 생성


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[Workflow Conclusion] --> B{Conclusion Type?}
  B -->|skipped| C["Set to 'success'<br/>Don't create issue]
  B -->|cancelled| D["Set to 'failure'<br/>Create issue"]
  B -->|success| E["Keep as 'success'<br/>Close stale issues"]
  B -->|failure| F["Keep as 'failure'<br/>Create issue"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>37_ci-failure-issues.yml</strong><dd><code>Fix skipped conclusion handling in CI failure workflow</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/37_ci-failure-issues.yml

<ul><li>'skipped' 결론을 'failure' 대신 'success'로 처리하도록 로직 변경<br> <li> 상위 워크플로우 성공 시 의도적으로 건너뛰는 CI Auto-Heal 등의 워크플로우 지원<br> <li> 'cancelled' runs는 여전히 실패로 처리되어 이슈 생성 로직 유지<br> <li> 기존 주석 개선으로 변경 사항의 근거 설명 추가</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/bug/pull/294/files#diff-b7915627bf5a3f819200e450f76d18990ded0c290cd731ef75bbb887a26bc3f9">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

