### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/actions/setup-build-cache/action.yml
+++ b/.github/actions/setup-build-cache/action.yml
@@ -25,13 +25,32 @@ runs:
         nas_base="/mnt/nas-cache"
         local_base="${RUNNER_TEMP:-/tmp}/gha-cache"
 
-        # Prefer the NAS mount; degrade to a local path if it is missing or
-        # not writable so a broken mount never hard-fails the build.
-        if [ -d "$nas_base" ] && [ -w "$nas_base" ]; then
-          base="$nas_base"
+        # Prefer the NAS mount; self-heal its permissions if needed (a freshly
+        # provisioned NFS volume is root-owned, but the runner is non-root).
+        # Degrade to a local path only if the NAS mount is truly unusable, so a
+        # broken mount never hard-fails the build.
+        base="$local_base"
+        if [ -d "$nas_base" ]; then
+          probe="$nas_base/.write-probe.$$"
+          if (mkdir -p "$nas_base/$runner_slug" && touch "$probe") >/dev/null 2>&1; then
+            rm -f "$probe"
+            base="$nas_base"
+          elif command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
+            # Self-heal: claim the cache tree for the runner user once.
+            if sudo mkdir -p "$nas_base" \
+               && sudo chown "$(id -u):$(id -g)" "$nas_base" \
+               && sudo chmod 0775 "$nas_base" \
+               && touch "$probe" >/dev/null 2>&1; then
+              rm -f "$probe"
+              base="$nas_base"
+              echo "build cache: self-healed NAS mount permissions on $nas_base"
+            fi
+          fi
+        fi
+
+        if [ "$base" = "$nas_base" ]; then
           echo "build cache: using NAS mount $nas_base"
         else
-          base="$local_base"
           echo "::warning::NAS mount $nas_base unavailable/unwritable; falling back to $local_base"
         fi
 


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `12_dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`20_readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`05_gitleaks.yml`, `06_codeql.yml`, `04_actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Enhancement


___

### **Description**
- NAS 마운트 권한 자동 복구(self-heal) 기능 추가

- 쓰기 프로브 파일을 통해 NAS 마운트 사용 가능 여부 확인

- NFS 볼륨의 root 소유권 문제를 runner 사용자로 자동 수정

- sudo 권한을 활용한 디렉토리 생성 및 권한 설정 로직 구현

- NAS 마운트가 실제로 사용 불가능할 때만 로컬 경로로 폴백


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["NAS 마운트 존재?<br>Check if NAS exists"] --> B{"쓰기 프로브<br>파일 테스트"}
  B -->|성공| C["NAS 사용<br>Use NAS mount"]
  B -->|실패| D{"sudo<br>사용 가능?"}
  D -->|예| E["권한 자동 복구<br>Self-heal permissions"]
  E --> C
  D -->|아니오| F["로컬 경로 폴백<br>Fallback to local"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>action.yml</strong><dd><code>NAS 마운트 권한 자동 복구 기능 구현</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/actions/setup-build-cache/action.yml

<ul><li>NAS 마운트 권한 문제 해결을 위한 자기복구(self-healing) 로직 추가<br> <li> mkdir + touch 프로브 파일로 실제 쓰기 가능 여부 검증<br> <li> sudo 권한 있을 경우 NFS 볼륨의 owner/chmod 자동 수정<br> <li> 이전의 단순 '디렉토리 존재 + 쓰기 가능' 체크를 고급 탐지 및 복구流程으로 대체</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/bug/pull/359/files#diff-e22dec1852d6dcbcb4a828b3ac0538fa7b31fc4cc637f5828e2111e763fba58c">+24/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

